### PR TITLE
break out meditation view and add media controls

### DIFF
--- a/conscious/conscious.xcodeproj/project.pbxproj
+++ b/conscious/conscious.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5CB0BA151C9291C20045901F /* media_meditation.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5CB0BA141C9291C20045901F /* media_meditation.storyboard */; };
 		912C76A9713F2DCF4F3A5C84 /* libPods-conscious.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AF2A56554296CAD3E80F515 /* libPods-conscious.a */; };
 		DA35019F1C880A27006A41A5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA35019E1C880A27006A41A5 /* AppDelegate.swift */; };
 		DA3501A11C880A27006A41A5 /* HomeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3501A01C880A27006A41A5 /* HomeTableViewController.swift */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		3AF2A56554296CAD3E80F515 /* libPods-conscious.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-conscious.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CB0BA141C9291C20045901F /* media_meditation.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = media_meditation.storyboard; sourceTree = "<group>"; };
 		8F0A3CA90B5EAA920D64E307 /* Pods-conscious.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-conscious.debug.xcconfig"; path = "Pods/Target Support Files/Pods-conscious/Pods-conscious.debug.xcconfig"; sourceTree = "<group>"; };
 		B24AE942D5D41CCB7D7F2C51 /* Pods-conscious.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-conscious.release.xcconfig"; path = "Pods/Target Support Files/Pods-conscious/Pods-conscious.release.xcconfig"; sourceTree = "<group>"; };
 		DA35019B1C880A27006A41A5 /* conscious.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = conscious.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,6 +104,32 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		5CB0BA111C92916B0045901F /* media_meditation */ = {
+			isa = PBXGroup;
+			children = (
+				5CB0BA131C92917F0045901F /* Models */,
+				5CB0BA121C9291740045901F /* Controllers */,
+				5CB0BA141C9291C20045901F /* media_meditation.storyboard */,
+			);
+			name = media_meditation;
+			sourceTree = "<group>";
+		};
+		5CB0BA121C9291740045901F /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				DA3501C11C8A7E9A006A41A5 /* MediaViewController.swift */,
+			);
+			name = Controllers;
+			sourceTree = "<group>";
+		};
+		5CB0BA131C92917F0045901F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				DA3501CC1C8CCE23006A41A5 /* Media.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
 		D9D6E06B6FE8CF0D49E40748 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -133,6 +161,7 @@
 		DA35019D1C880A27006A41A5 /* conscious */ = {
 			isa = PBXGroup;
 			children = (
+				5CB0BA111C92916B0045901F /* media_meditation */,
 				DA3501F41C926A11006A41A5 /* timed_mediation */,
 				DA3501DB1C8FDDA6006A41A5 /* backgroundImages */,
 				DA3501D21C8CE4D0006A41A5 /* Audio */,
@@ -173,7 +202,6 @@
 			children = (
 				DA3501A01C880A27006A41A5 /* HomeTableViewController.swift */,
 				DA3501BF1C8A749E006A41A5 /* CategoryViewController.swift */,
-				DA3501C11C8A7E9A006A41A5 /* MediaViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -184,7 +212,6 @@
 				DA3501D81C8CEDB5006A41A5 /* AudioEffects */,
 				DA3501C81C8CCDF5006A41A5 /* Category.swift */,
 				DA3501CA1C8CCE00006A41A5 /* History.swift */,
-				DA3501CC1C8CCE23006A41A5 /* Media.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -326,6 +353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA3501D61C8CE4FC006A41A5 /* MARC5MinuteBreathing.mp3 in Resources */,
+				5CB0BA151C9291C20045901F /* media_meditation.storyboard in Resources */,
 				DA3501A91C880A27006A41A5 /* LaunchScreen.storyboard in Resources */,
 				DA3501E51C8FDECA006A41A5 /* sunset1.gif in Resources */,
 				DA3501E61C8FDECA006A41A5 /* waterfall1.gif in Resources */,

--- a/conscious/conscious/Base.lproj/Main.storyboard
+++ b/conscious/conscious/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="q8l-g0-1zT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="q8l-g0-1zT">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -52,7 +52,7 @@
                                                     <rect key="frame" x="180" y="18" width="240" height="60"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lk9-f1-q8H">
-                                                            <rect key="frame" x="3" y="13.5" width="234" height="33"/>
+                                                            <rect key="frame" x="3" y="14" width="234" height="33"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="33" id="28h-AQ-DWZ"/>
                                                                 <constraint firstAttribute="width" constant="234" id="dZv-zs-Mwc"/>
@@ -97,9 +97,9 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Category Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S9L-Oa-cBf">
-                                                    <rect key="frame" x="61" y="22.5" width="120" height="20.5"/>
+                                                    <rect key="frame" x="61" y="23" width="120" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -121,7 +121,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" image="exampleMeditionCover" translatesAutoresizingMaskIntoConstraints="NO" id="zII-Ka-fQ3">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="616.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="617"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="cVh-MW-d6e"/>
                                                     </constraints>
@@ -141,9 +141,9 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Mediation Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GDk-PI-Etw">
-                                                                <rect key="frame" x="53" y="24" width="125" height="20.5"/>
+                                                                <rect key="frame" x="53" y="24" width="125" height="21"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
@@ -191,43 +191,6 @@
             </objects>
             <point key="canvasLocation" x="1090" y="339"/>
         </scene>
-        <!--Media View Controller-->
-        <scene sceneID="pwg-5K-kq1">
-            <objects>
-                <viewController storyboardIdentifier="MediaViewController" id="IHv-Ek-HpY" customClass="MediaViewController" customModule="conscious" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="1MJ-4Q-Xu9"/>
-                        <viewControllerLayoutGuide type="bottom" id="r5e-2z-ql0"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="Yd6-Ah-pq4">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CTH-nj-IhO">
-                                <rect key="frame" x="278" y="285" width="44" height="30"/>
-                                <state key="normal" title="Play▶︎">
-                                    <color key="titleColor" red="0.16569926340976027" green="0.17961675289449719" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="playSound:" destination="IHv-Ek-HpY" eventType="touchUpInside" id="LBt-jh-rlm"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" red="0.52635605378362915" green="1" blue="0.57897882809018797" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="tintColor" red="0.69009782016649046" green="1" blue="0.54698733191160198" alpha="1" colorSpace="calibratedRGB"/>
-                        <accessibility key="accessibilityConfiguration">
-                            <accessibilityTraits key="traits" playsSound="YES"/>
-                        </accessibility>
-                        <constraints>
-                            <constraint firstItem="CTH-nj-IhO" firstAttribute="centerX" secondItem="Yd6-Ah-pq4" secondAttribute="centerX" id="JDW-Tx-DbS"/>
-                            <constraint firstItem="CTH-nj-IhO" firstAttribute="centerY" secondItem="Yd6-Ah-pq4" secondAttribute="centerY" id="bKG-4o-apY"/>
-                        </constraints>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Faw-vX-U1C" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="654" y="1736"/>
-        </scene>
         <!--Category View Controller-->
         <scene sceneID="uru-ZU-OT3">
             <objects>
@@ -252,7 +215,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" image="exampleMeditionCover" translatesAutoresizingMaskIntoConstraints="NO" id="wkT-Gg-670">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="616.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="617"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="RTF-35-FAR"/>
                                                     </constraints>
@@ -272,9 +235,9 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Mediation Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bof-Px-M83">
-                                                                <rect key="frame" x="53" y="24" width="125" height="20.5"/>
+                                                                <rect key="frame" x="53" y="24" width="125" height="21"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>

--- a/conscious/conscious/MediaTableViewCell.swift
+++ b/conscious/conscious/MediaTableViewCell.swift
@@ -27,9 +27,9 @@ class MediaTableViewCell: UITableViewCell {
     }
     
     func onTap(){
-        let storyBoard = UIStoryboard(name: "Main", bundle: nil)
-        if let timerViewController  = storyBoard.instantiateViewControllerWithIdentifier("MediaViewController") as? MediaViewController{
-            self.navigationController?.pushViewController(timerViewController, animated: true)
+        let storyBoard = UIStoryboard(name: "media_meditation", bundle: nil)
+        if let mediaViewController  = storyBoard.instantiateViewControllerWithIdentifier("MediaViewController") as? MediaViewController{
+            self.navigationController?.pushViewController(mediaViewController, animated: true)
         }
     }
 

--- a/conscious/conscious/media_meditation.storyboard
+++ b/conscious/conscious/media_meditation.storyboard
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <scenes>
+        <!--Media Meditation-->
+        <scene sceneID="aXN-oE-PeL">
+            <objects>
+                <viewController storyboardIdentifier="MediaViewController" title="Media Meditation" id="xZ1-Jg-0QA" customClass="MediaViewController" customModule="conscious" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="hBW-h3-gPX"/>
+                        <viewControllerLayoutGuide type="bottom" id="iRv-xM-wNa"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="2f2-ut-DKj">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="0At-Zh-jTa">
+                                <rect key="frame" x="50" y="485" width="500" height="31"/>
+                                <connections>
+                                    <action selector="scrubTimeSlider:" destination="xZ1-Jg-0QA" eventType="valueChanged" id="Vq8-IB-zwi"/>
+                                </connections>
+                            </slider>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ijJ-In-Xx5">
+                                <rect key="frame" x="20" y="522.5" width="61" height="20.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="61" id="ZSS-T7-Ucl"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="15:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7eF-Ie-fJl">
+                                <rect key="frame" x="506" y="522.5" width="74" height="20.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="74" id="fEa-jS-PfH"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8bW-r9-8lr">
+                                <rect key="frame" x="268" y="407" width="65" height="65"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="65" id="Eip-1t-8UZ"/>
+                                    <constraint firstAttribute="height" constant="65" id="LM0-dl-eVU"/>
+                                </constraints>
+                                <state key="normal">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="togglePlayingSound:" destination="xZ1-Jg-0QA" eventType="touchUpInside" id="yJ5-i6-edB"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="0.52635605379999995" green="1" blue="0.57897882810000001" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="tintColor" red="0.69009782019999999" green="1" blue="0.54698733190000004" alpha="1" colorSpace="calibratedRGB"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" playsSound="YES"/>
+                        </accessibility>
+                        <constraints>
+                            <constraint firstItem="iRv-xM-wNa" firstAttribute="top" secondItem="0At-Zh-jTa" secondAttribute="bottom" constant="85" id="6NX-nd-Wyf"/>
+                            <constraint firstItem="8bW-r9-8lr" firstAttribute="centerX" secondItem="2f2-ut-DKj" secondAttribute="centerX" id="9X4-Lp-g6N"/>
+                            <constraint firstItem="ijJ-In-Xx5" firstAttribute="leading" secondItem="2f2-ut-DKj" secondAttribute="leading" constant="20" id="9j5-dd-kRf"/>
+                            <constraint firstItem="8bW-r9-8lr" firstAttribute="centerY" secondItem="2f2-ut-DKj" secondAttribute="centerY" constant="28.5" id="Cag-EW-fNs"/>
+                            <constraint firstItem="7eF-Ie-fJl" firstAttribute="top" secondItem="0At-Zh-jTa" secondAttribute="bottom" constant="8" id="MkC-ch-Y6d"/>
+                            <constraint firstItem="0At-Zh-jTa" firstAttribute="top" secondItem="8bW-r9-8lr" secondAttribute="bottom" constant="13" id="ShN-3a-gIw"/>
+                            <constraint firstAttribute="trailing" secondItem="0At-Zh-jTa" secondAttribute="trailing" constant="52" id="UlG-sv-47C"/>
+                            <constraint firstItem="0At-Zh-jTa" firstAttribute="leading" secondItem="2f2-ut-DKj" secondAttribute="leading" constant="52" id="cAU-uo-Yjd"/>
+                            <constraint firstItem="8bW-r9-8lr" firstAttribute="centerX" secondItem="0At-Zh-jTa" secondAttribute="centerX" id="d7J-PG-GwB"/>
+                            <constraint firstAttribute="trailing" secondItem="7eF-Ie-fJl" secondAttribute="trailing" constant="20" id="oR1-NZ-gh2"/>
+                            <constraint firstItem="ijJ-In-Xx5" firstAttribute="top" secondItem="0At-Zh-jTa" secondAttribute="bottom" constant="8" id="zBc-dI-tIc"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="9X4-Lp-g6N"/>
+                                <exclude reference="Cag-EW-fNs"/>
+                            </mask>
+                        </variation>
+                    </view>
+                    <connections>
+                        <outlet property="currentTimeLabel" destination="ijJ-In-Xx5" id="pPB-AQ-n44"/>
+                        <outlet property="playPauseButton" destination="8bW-r9-8lr" id="5kg-L5-JBd"/>
+                        <outlet property="timeLeftLabel" destination="7eF-Ie-fJl" id="BWn-kK-D9m"/>
+                        <outlet property="timeSlider" destination="0At-Zh-jTa" id="V02-YD-nUg"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YSz-91-grG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="686" y="1416"/>
+        </scene>
+    </scenes>
+</document>

--- a/conscious/conscious/timed_meditation.storyboard
+++ b/conscious/conscious/timed_meditation.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -49,15 +49,15 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Max Freq" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zft-f8-vcQ">
-                                <rect key="frame" x="265" y="370" width="71" height="20.5"/>
+                                <rect key="frame" x="265" y="370" width="71" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EaT-kS-78Y">
-                                <rect key="frame" x="26" y="28" width="71.5" height="20.5"/>
+                                <rect key="frame" x="26" y="28" width="72" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lfr-xp-dNQ" customClass="UIWebView">
@@ -91,8 +91,8 @@
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
-                                <exclude reference="9qG-ZT-YLO"/>
                                 <exclude reference="4KP-BU-rJ6"/>
+                                <exclude reference="9qG-ZT-YLO"/>
                                 <exclude reference="vpd-EL-udH"/>
                             </mask>
                         </variation>
@@ -125,7 +125,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FiW-wY-9Hf" id="rXp-7y-Jej">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -133,19 +133,19 @@
                                         <rect key="frame" x="0.0" y="44" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NMY-06-2H3" id="18x-wm-E5Q">
-                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5 min" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ty0-2j-d1a">
                                                     <rect key="frame" x="477" y="11" width="43" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time Interval" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qWy-Qd-7X4">
                                                     <rect key="frame" x="14" y="11" width="99" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -161,19 +161,19 @@
                                         <rect key="frame" x="0.0" y="88" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="k7L-eD-Wri" id="e4Z-XK-RNp">
-                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Riminder Tone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5s-WN-GZo">
-                                                    <rect key="frame" x="14" y="11" width="110" height="20.5"/>
+                                                    <rect key="frame" x="14" y="11" width="110" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bell" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vJw-vv-ygF">
-                                                    <rect key="frame" x="491" y="11" width="28" height="20.5"/>
+                                                    <rect key="frame" x="491" y="11" width="28" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -189,19 +189,19 @@
                                         <rect key="frame" x="0.0" y="132" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hUy-UZ-q8f" id="OJw-uw-JLK">
-                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ayi-Op-5gw">
-                                                    <rect key="frame" x="486" y="11.5" width="41" height="20.5"/>
+                                                    <rect key="frame" x="486" y="12" width="41" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Background Sounds" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yT0-25-Kne">
-                                                    <rect key="frame" x="14" y="11.5" width="154.5" height="20.5"/>
+                                                    <rect key="frame" x="14" y="12" width="155" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -217,13 +217,13 @@
                                         <rect key="frame" x="0.0" y="176" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="RJS-cN-V4p" id="lK2-tv-gD0">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hOm-F9-GjG">
-                                                    <rect key="frame" x="14" y="11.5" width="123.5" height="20.5"/>
+                                                    <rect key="frame" x="14" y="12" width="124" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yj7-L0-CWe">


### PR DESCRIPTION
@pthor 
Break out Meditation View to its own Storyboard
Display the playback time elapsed and remaining which can be used to power a visualization or display time elapsed/remaining. 
Implemented scrubbing to a specific point in the media
Implemented delegate method on audio Finish Playing for segue
:8ball: :musical_keyboard: 
closes #13
