### PR TITLE
Small fix so that event is triggered first time UIDatePicker value changes

### DIFF
--- a/conscious/conscious/TimePickerView.swift
+++ b/conscious/conscious/TimePickerView.swift
@@ -1,0 +1,23 @@
+//
+//  TimePickerView.swift
+//  conscious
+//
+//  Created by Paul Thormahlen on 3/10/16.
+//  Copyright © 2016 Conscious World. All rights reserved.
+//
+
+import UIKit
+
+class TimePickerView: UIDatePicker {
+
+    var settings: TimerSettings?
+ 
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.addTarget(self, action: Selector("timePickerChanged:"), forControlEvents: UIControlEvents.ValueChanged)
+    }
+    
+    func timePickerChanged(timePicker:UIDatePicker) {
+        settings?.intervalSeconds = self.countDownDuration
+    }
+}

--- a/conscious/conscious/TimerSettingsTableViewController.swift
+++ b/conscious/conscious/TimerSettingsTableViewController.swift
@@ -15,7 +15,9 @@ class TimerSettingsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         timePicker.settings = settings
-        timePicker.countDownDuration = settings.intervalSeconds
+        dispatch_async(dispatch_get_main_queue(),{
+            self.timePicker.countDownDuration = self.settings.intervalSeconds
+        })
     }
    
 }


### PR DESCRIPTION
Fix first timer settings change event to actually fire

Somehow, setting the pickers initial value asycronously on the main thread fixes the issue.  Maybe it causes the first event to happen on set so when the user changes the value its the second time?  idk. 
http://stackoverflow.com/questions/20181980/uidatepicker-bug-uicontroleventvaluechanged-after-hitting-minimum-internal

Add TimePickerView file that I missed in last PR
